### PR TITLE
fix caiman key typo to properly grab videos

### DIFF
--- a/docs/examples/isx_notebooks/isx_plus_caiman.ipynb
+++ b/docs/examples/isx_notebooks/isx_plus_caiman.ipynb
@@ -1,0 +1,149 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Purpose\n",
+   "id": "a6d3db6fdb9458ce"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "This notebook demonstrates the integration between ISX and Caiman modules.",
+   "id": "25b399be26e943cb"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "!mkdir -p ./conda_env\n",
+    "\n",
+    "!wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O Miniforge3.sh\n",
+    "!bash Miniforge3.sh -b -p ./conda_env/miniforge3"
+   ],
+   "id": "8ba416067160985d",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "!source ./conda_env/miniforge3/etc/profile.d/conda.sh && conda create -n caiman-env python=3.10 -c conda-forge -y",
+   "id": "6c9991f833df30b9",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "!source ./conda_env/miniforge3/etc/profile.d/conda.sh && conda activate caiman-env && conda install mamba -c conda-forge -y\n",
+   "id": "1aa4712f81fc21b7",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "!source ./conda_env/miniforge3/etc/profile.d/conda.sh && conda activate caiman-env && mamba install -c conda-forge caiman -y\n",
+   "id": "485df185fbdc9194",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "import sys\n",
+    "sys.executable = \"./conda_env/miniforge3/envs/caiman-env/bin/python\"\n",
+    "!which python"
+   ],
+   "id": "c322722181f2545f",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "!source ./conda_env/miniforge3/etc/profile.d/conda.sh && conda activate caiman-env && python -c \"import caiman; print('CaImAn OK')\"\n",
+   "id": "d9bed1d2bb091de0",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "!python -m ipykernel install --user --name=conda_env --display-name=\"Conda env with caiman\"",
+   "id": "78db8866d10fdb9f",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "import caiman",
+   "id": "9992a112908a4396",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "import isx",
+   "id": "aa2f07ac86d6782e",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "from ci_pipe.pipeline import CIPipe",
+   "id": "7816d18dbbc2a2a0",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "pipeline = CIPipe.with_videos_from_directory('input_dir', outputs_directory='output_dir', isx=isx, caiman=caiman)",
+   "id": "19eb66b5c6fe2c95",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "(\n",
+    "    pipeline\n",
+    "    .isx.preprocess_videos()\n",
+    "    .isx.export_movie_to_tiff()\n",
+    "    .caiman.motion_correction()\n",
+    ")"
+   ],
+   "id": "5399f1d331e85981",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Conda env with caiman",
+   "language": "python",
+   "name": "conda_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cipipeline"
-version = "0.1.4"
+version = "0.2.0"
 description = "CIPipeline is a tool to analyze and process Calcium Imaging data."
 readme = "README.md"
 requires-python = ">=3.10,<3.11"
@@ -32,7 +32,7 @@ pythonpath = ["src"]
 testpaths = ["tests"]
 
 [tool.bumpver]
-current_version = "0.1.4"
+current_version = "0.2.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "Bump version to {new_version}"
 tag_message = "v{new_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cipipeline"
-version = "0.2.0"
+version = "0.3.0"
 description = "CIPipeline is a tool to analyze and process Calcium Imaging data."
 readme = "README.md"
 requires-python = ">=3.10,<3.11"
@@ -32,7 +32,7 @@ pythonpath = ["src"]
 testpaths = ["tests"]
 
 [tool.bumpver]
-current_version = "0.2.0"
+current_version = "0.3.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "Bump version to {new_version}"
 tag_message = "v{new_version}"

--- a/src/ci_pipe/modules/caiman_module.py
+++ b/src/ci_pipe/modules/caiman_module.py
@@ -32,7 +32,7 @@ class CaimanModule:
         output = []
         output_dir = self._ci_pipe.create_output_directory_for_next_step(self.MOTION_CORRECTION_STEP)
 
-        for input_data in inputs('videos-tif'):
+        for input_data in inputs('videos-tiff'):
             motion_correct_handler = self._caiman.motion_correction.MotionCorrect(
                 fname=input_data['value'],
                 strides=caiman_strides,
@@ -59,7 +59,7 @@ class CaimanModule:
             memmapped_movie.save(tif_output_path)
             output.append({'ids': input_data['ids'], 'value': tif_output_path})
 
-        return {"videos-tif": output}
+        return {"videos-tiff": output}
 
     @step(CNMF_STEP)
     def cnmf(
@@ -141,7 +141,7 @@ class CaimanModule:
         output = []
         output_dir = self._ci_pipe.create_output_directory_for_next_step(self.CNMF_STEP)
 
-        for input_data in inputs('videos-tif'):
+        for input_data in inputs('videos-tiff'):
             cnmf_model = self._caiman.source_extraction.cnmf.CNMF(
                 n_processes=caiman_n_processes,
                 k=caiman_k,

--- a/tests/caiman_test.py
+++ b/tests/caiman_test.py
@@ -22,7 +22,7 @@ class CaimanTestCase(CIPipeTestCase):
         # Given
         pipeline_input = 'input_dir'
         self._file_system.makedirs(pipeline_input)
-        self._file_system.write(f'{pipeline_input}/file1.tif', '')
+        self._file_system.write(f'{pipeline_input}/file1.tiff', '')
         pipeline = CIPipe.with_videos_from_directory(
             pipeline_input,
             file_system=self._file_system,
@@ -35,7 +35,7 @@ class CaimanTestCase(CIPipeTestCase):
         # Then
         self._assert_output_files(
             pipeline,
-            'videos-tif',
+            'videos-tiff',
             [
                 'output/Main Branch - Step 1 - Caiman Motion Correction/file1-MC.tif',
             ],
@@ -47,7 +47,7 @@ class CaimanTestCase(CIPipeTestCase):
         # Given
         pipeline_input = 'input_dir'
         self._file_system.makedirs(pipeline_input)
-        self._file_system.write(f'{pipeline_input}/file1.tif', '')
+        self._file_system.write(f'{pipeline_input}/file1.tiff', '')
         pipeline = CIPipe.with_videos_from_directory(
             pipeline_input,
             file_system=self._file_system,
@@ -61,7 +61,7 @@ class CaimanTestCase(CIPipeTestCase):
         # Then
         self._assert_output_files(
             pipeline,
-            'videos-tif',
+            'videos-tiff',
             [
                 'output/Main Branch - Step 1 - Caiman Motion Correction/file1-MC.tif',
             ],


### PR DESCRIPTION
# Merge Request

## Description

When using the collab notebook to integrate both isx and caiman we've realized we had a typo that wasn't allowing us to grab the video properly. The correct format extension is tiff with double 'f'.

Summary of changes

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Other (specify)
